### PR TITLE
flur 319 fix plan menu overlap

### DIFF
--- a/src/components/content/edit/panels/plan.vue
+++ b/src/components/content/edit/panels/plan.vue
@@ -997,7 +997,7 @@ export default {
 
             th:first-child,
             th:last-child {
-                z-index: 5;
+                z-index: 4;
             }
         }
 


### PR DESCRIPTION
- Fix menu overlap on new-Plan menu
BEFORE:
![image](https://user-images.githubusercontent.com/102111077/160484989-24441376-29fc-4d59-84ef-bfa9e1a8009c.png)

AFTER:
![image](https://user-images.githubusercontent.com/102111077/160484808-78f238e0-20ae-4e05-91f3-4916d663a64e.png)
