### PR TITLE
378 calendary one day off

### DIFF
--- a/src/components/form/FluroContentFormField.vue
+++ b/src/components/form/FluroContentFormField.vue
@@ -2198,8 +2198,7 @@ export default {
 			if (self.fieldModel === undefined || self.fieldModel === null || self.fieldModel === '') {
 				return;
 			}
-
-			return self.fieldModel ? self.$fluro.date.moment(self.fieldModel).format(self.dateFormat) : '';
+			return self.fieldModel ? self.$fluro.date.moment(self.fieldModel).utc().format(self.dateFormat) : '';
 		},
 		// formattedDate() {
 		//     return this.$fluro.date.formatDate(this.fieldModel, 'dddd D MMM YYYY');


### PR DESCRIPTION
- fix the bug where calendar selects yesterday for timezones a way behind UTC

I'm fixing this by keeping the date in UTC. This seems to me the correct solution as it can't make much use of timezone unless paired with a time somewhere further up the stack. I tested in Central time, India time, and East-of-Japan time (tomorrow in UTC) and it worked for all.

<img width="237" alt="image" src="https://user-images.githubusercontent.com/102111077/162010141-7fd8a665-e7df-467f-9d60-456343f2c4a5.png">
<img width="208" alt="image" src="https://user-images.githubusercontent.com/102111077/162010168-b8125afe-a433-4b10-a66e-0ae1d59765e6.png">
